### PR TITLE
Config Validators and Documentation

### DIFF
--- a/src/capy_app/config.py
+++ b/src/capy_app/config.py
@@ -60,7 +60,11 @@ class Settings(BaseSettings):
     @field_validator("MONGO_URI")
     def validate_mongo_uri(cls, v):
         """Check if Mongo URI is a valid URI"""
-        if (v is not None and not v.startswith("mongodb://") and not v.startswith("mongodb+srv://")):
+        if (
+            v is not None
+            and not v.startswith("mongodb://")
+            and not v.startswith("mongodb+srv://")
+        ):
             raise ValueError(
                 'MONGO_URI must start with "mongodb://" or "mongodb+srv://"'
             )
@@ -83,14 +87,30 @@ class Settings(BaseSettings):
     @field_validator("ENABLE_CHATBOT")
     def validate_enable_chatbot(cls, v):
         """Check if enable_chatbot variable is a boolean value"""
-        if v != True and v != False:
+        if v is not True and v is not False:
             raise ValueError("ENABLE_CHATBOT must be 'True' or 'False'")
         return v
 
-    @field_validator("BOT_TOKEN", "MONGO_URI", "MONGO_DBNAME", "MONGO_USERNAME", "MONGO_PASSWORD", "MAILJET_API_KEY", "MAILJET_API_SECRET",
-    "MAILJET_API_EMAIL", "TICKET_BUG_REPORT_CHANNEL_ID", "TICKET_FEATURE_REQUEST_CHANNEL_ID", "TICKET_FEEDBACK_CHANNEL_ID", "WHO_DUNNIT",
-    "FAILED_COMMANDS_GUILD_ID", "FAILED_COMMANDS_CHANNEL_ID", "FAILED_COMMANDS_ROLE_ID","ENABLE_CHATBOT",
-    "MODEL_NAME", "DEBUG_GUILD_ID")
+    @field_validator(
+        "BOT_TOKEN",
+        "MONGO_URI",
+        "MONGO_DBNAME",
+        "MONGO_USERNAME",
+        "MONGO_PASSWORD",
+        "MAILJET_API_KEY",
+        "MAILJET_API_SECRET",
+        "MAILJET_API_EMAIL",
+        "TICKET_BUG_REPORT_CHANNEL_ID",
+        "TICKET_FEATURE_REQUEST_CHANNEL_ID",
+        "TICKET_FEEDBACK_CHANNEL_ID",
+        "WHO_DUNNIT",
+        "FAILED_COMMANDS_GUILD_ID",
+        "FAILED_COMMANDS_CHANNEL_ID",
+        "FAILED_COMMANDS_ROLE_ID",
+        "ENABLE_CHATBOT",
+        "MODEL_NAME",
+        "DEBUG_GUILD_ID",
+    )
     def validate_fields(cls, v, info):
         """Check if any of the env variables are empty/missing"""
         if v is None or v == "":

--- a/src/capy_app/config.py
+++ b/src/capy_app/config.py
@@ -59,11 +59,8 @@ class Settings(BaseSettings):
     # Validators
     @field_validator("MONGO_URI")
     def validate_mongo_uri(cls, v):
-        if (
-            v is not None
-            and not v.startswith("mongodb://")
-            and not v.startswith("mongodb+srv://")
-        ):
+        """Check if Mongo URI is a valid URI"""
+        if (v is not None and not v.startswith("mongodb://") and not v.startswith("mongodb+srv://")):
             raise ValueError(
                 'MONGO_URI must start with "mongodb://" or "mongodb+srv://"'
             )
@@ -71,16 +68,33 @@ class Settings(BaseSettings):
 
     @field_validator("MAILJET_API_EMAIL")
     def validate_email(cls, v):
+        """Check if the MailJet API email is a valid email"""
         if v and "@" not in v:
             raise ValueError("MAILJET_API_EMAIL must be a valid email address")
         return v
 
-    @field_validator(
-        "FAILED_COMMANDS_INVITE_EXPIRY", "FAILED_COMMANDS_INVITE_USES", "MESSAGE_LIMIT"
-    )
-    def validate_positive_numbers(cls, v):
-        if v is not None and v <= 0:
-            raise ValueError("Value must be a positive integer")
+    @field_validator("MONGO_DBNAME")
+    def validate_mongo_dbname(cls, v):
+        """Check if the Mongo DB name is a valid database name"""
+        if " " in v:
+            raise ValueError("MONGO_DBNAME must not contain spaces.")
+        return v
+
+    @field_validator("ENABLE_CHATBOT")
+    def validate_enable_chatbot(cls, v):
+        """Check if enable_chatbot variable is a boolean value"""
+        if v != True and v != False:
+            raise ValueError("ENABLE_CHATBOT must be 'True' or 'False'")
+        return v
+
+    @field_validator("BOT_TOKEN", "MONGO_URI", "MONGO_DBNAME", "MONGO_USERNAME", "MONGO_PASSWORD", "MAILJET_API_KEY", "MAILJET_API_SECRET",
+    "MAILJET_API_EMAIL", "TICKET_BUG_REPORT_CHANNEL_ID", "TICKET_FEATURE_REQUEST_CHANNEL_ID", "TICKET_FEEDBACK_CHANNEL_ID", "WHO_DUNNIT",
+    "FAILED_COMMANDS_GUILD_ID", "FAILED_COMMANDS_CHANNEL_ID", "FAILED_COMMANDS_ROLE_ID","ENABLE_CHATBOT",
+    "MODEL_NAME", "DEBUG_GUILD_ID")
+    def validate_fields(cls, v, info):
+        """Check if any of the env variables are empty/missing"""
+        if v is None or v == "":
+            raise ValueError(f"Field '{info.field_name}' is empty.")
         return v
 
 

--- a/src/capy_app/config.py
+++ b/src/capy_app/config.py
@@ -21,7 +21,7 @@ class Settings(BaseSettings):
     # Email settings
     MAILJET_API_KEY: Optional[str] = ""
     MAILJET_API_SECRET: Optional[str] = ""
-    MAILJET_EMAIL_ADDRESS: Optional[str] = ""
+    MAILJET_API_EMAIL: Optional[str] = ""
 
     # Channel settings
     WHO_DUNNIT: Optional[str] = None
@@ -57,23 +57,32 @@ class Settings(BaseSettings):
     }
 
     # Validators
-    @field_validator('MONGO_URI')
+    @field_validator("MONGO_URI")
     def validate_mongo_uri(cls, v):
-        if v is not None and not v.startswith('mongodb://') and not v.startswith('mongodb+srv://'):
-            raise ValueError('MONGO_URI must start with "mongodb://" or "mongodb+srv://"')
+        if (
+            v is not None
+            and not v.startswith("mongodb://")
+            and not v.startswith("mongodb+srv://")
+        ):
+            raise ValueError(
+                'MONGO_URI must start with "mongodb://" or "mongodb+srv://"'
+            )
         return v
 
-    @field_validator('MAILJET_EMAIL_ADDRESS')
+    @field_validator("MAILJET_API_EMAIL")
     def validate_email(cls, v):
         if v and "@" not in v:
-            raise ValueError('MAILJET_EMAIL_ADDRESS must be a valid email address')
+            raise ValueError("MAILJET_API_EMAIL must be a valid email address")
         return v
 
-    @field_validator('FAILED_COMMANDS_INVITE_EXPIRY', 'FAILED_COMMANDS_INVITE_USES', 'MESSAGE_LIMIT')
+    @field_validator(
+        "FAILED_COMMANDS_INVITE_EXPIRY", "FAILED_COMMANDS_INVITE_USES", "MESSAGE_LIMIT"
+    )
     def validate_positive_numbers(cls, v):
         if v is not None and v <= 0:
-            raise ValueError('Value must be a positive integer')
+            raise ValueError("Value must be a positive integer")
         return v
+
 
 @lru_cache()
 def get_settings() -> Settings:

--- a/src/capy_app/config.py
+++ b/src/capy_app/config.py
@@ -1,6 +1,7 @@
 from pydantic_settings import BaseSettings
 from functools import lru_cache
 from typing import Optional
+from pydantic import field_validator
 
 
 class Settings(BaseSettings):
@@ -55,6 +56,24 @@ class Settings(BaseSettings):
         "case_sensitive": True,
     }
 
+    # Validators
+    @field_validator('MONGO_URI')
+    def validate_mongo_uri(cls, v):
+        if v is not None and not v.startswith('mongodb://') and not v.startswith('mongodb+srv://'):
+            raise ValueError('MONGO_URI must start with "mongodb://" or "mongodb+srv://"')
+        return v
+
+    @field_validator('MAILJET_EMAIL_ADDRESS')
+    def validate_email(cls, v):
+        if v and "@" not in v:
+            raise ValueError('MAILJET_EMAIL_ADDRESS must be a valid email address')
+        return v
+
+    @field_validator('FAILED_COMMANDS_INVITE_EXPIRY', 'FAILED_COMMANDS_INVITE_USES', 'MESSAGE_LIMIT')
+    def validate_positive_numbers(cls, v):
+        if v is not None and v <= 0:
+            raise ValueError('Value must be a positive integer')
+        return v
 
 @lru_cache()
 def get_settings() -> Settings:

--- a/src/capy_app/config.py
+++ b/src/capy_app/config.py
@@ -2,6 +2,10 @@ from pydantic_settings import BaseSettings
 from functools import lru_cache
 from typing import Optional
 from pydantic import field_validator
+import re
+
+# Regex for Email Validation
+regex = r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,7}\b'
 
 
 class Settings(BaseSettings):
@@ -73,7 +77,7 @@ class Settings(BaseSettings):
     @field_validator("MAILJET_API_EMAIL")
     def validate_email(cls, v):
         """Check if the MailJet API email is a valid email"""
-        if v and "@" not in v:
+        if not (re.fullmatch(regex, v)):
             raise ValueError("MAILJET_API_EMAIL must be a valid email address")
         return v
 


### PR DESCRIPTION
## Summary by Sourcery

Add input validation for several configuration settings, including the MongoDB connection URI, Mailjet API email, and various expiry and limit values. Rename the `MAILJET_EMAIL_ADDRESS` setting to `MAILJET_API_EMAIL`.

Enhancements:
- Add validators for `MONGO_URI`, `MAILJET_API_EMAIL`, `FAILED_COMMANDS_INVITE_EXPIRY`, `FAILED_COMMANDS_INVITE_USES`, and `MESSAGE_LIMIT` environment variables.
- Rename `MAILJET_EMAIL_ADDRESS` to `MAILJET_API_EMAIL` for clarity and consistency