### PR TITLE
Fix 2 duplicate instances of logs going to the console

### DIFF
--- a/src/capy_app/backend/modules/email.py
+++ b/src/capy_app/backend/modules/email.py
@@ -61,8 +61,6 @@ class Email:
         result = self.mailjet.send.create(data=data)
         if result.status_code == 200:
             return result.json()
-        err =  EmailSendError(
+        raise EmailSendError(
             f"Failed to send email: {result.status_code} - {result.json()}"
         )
-        self.logger.exception(err, stack_info=True)
-        raise err

--- a/src/capy_app/frontend/cogs/features/guild_cog.py
+++ b/src/capy_app/frontend/cogs/features/guild_cog.py
@@ -120,9 +120,7 @@ class GuildCog(commands.Cog):
     async def show_settings(self, interaction: discord.Interaction) -> None:
         """Display current server settings."""
         if not isinstance(interaction.guild, discord.Guild):
-            err = TypeError("Interaction must be in a guild.")
-            self.logger.error(err)
-            raise err
+            raise TypeError("Interaction must be in a guild.")
 
         await interaction.response.defer(ephemeral=True)
 
@@ -158,9 +156,7 @@ class GuildCog(commands.Cog):
     async def edit_settings(self, interaction: discord.Interaction) -> None:
         """Edit server settings using the new dropdown framework."""
         if not isinstance(interaction.guild, discord.Guild):
-            err = TypeError("Interaction must be in a guild.")
-            self.logger.error(err)
-            raise err
+            raise TypeError("Interaction must be in a guild.")
 
         try:
             setting_type, message = await self._process_settings_selection(interaction)


### PR DESCRIPTION
Since we're now logging uncaught exceptions, we no longer need to both have a logger.exception and a raise call.