### PR TITLE
Merge pre-commit integration into develop

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,10 @@ repos:
       hooks:
       -   id: mypy
           args: [ --strict, --ignore-missing-imports ]
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.1.2
+    hooks:
+      - id: flake8
 default_stages: [pre-commit, pre-push]
 default_language_version:
     python: python3.12

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  -   repo: https://github.com/pre-commit/mirrors-mypy
+      rev: '1.15.0'
+      hooks:
+      -   id: mypy
+          args: [ --strict, --ignore-missing-imports ]
+default_stages: [pre-commit, pre-push]
+default_language_version:
+    python: python3.12

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   -   repo: https://github.com/pre-commit/mirrors-mypy
-      rev: '1.15.0'
+      rev: v1.15.0
       hooks:
       -   id: mypy
           args: [ --strict, --ignore-missing-imports ]

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -18,3 +18,4 @@ Flask==3.1.0
 mailjet-rest==1.3.4
 ollama==0.4.7
 pydantic_settings==2.7.1
+pre-commit==4.1.0


### PR DESCRIPTION
Adds in the pre-commit library for running tests (in our case mypy and flake8) before commits and pushes.

## Summary by Sourcery

Build:
- Add pre-commit configuration file. Add pre-commit as a development dependency.