### PR TITLE
Merge in all the database restriction files, now un-futured!

### DIFF
--- a/src/capy_app/backend/db/documents/event.py
+++ b/src/capy_app/backend/db/documents/event.py
@@ -2,8 +2,10 @@ import typing
 import datetime
 import mongoengine
 
+from capy_app.backend.db.documents.restrict import RestrictedEmbeddedDocument, RestrictedDocument
 
-class EventReactions(mongoengine.EmbeddedDocument):
+
+class EventReactions(RestrictedEmbeddedDocument):
     """Tracks reaction counts for an event.
 
     Attributes:
@@ -17,7 +19,7 @@ class EventReactions(mongoengine.EmbeddedDocument):
     no: int = mongoengine.IntField(default=0)
 
 
-class EventDetails(mongoengine.EmbeddedDocument):
+class EventDetails(RestrictedEmbeddedDocument):
     """Stores detailed information about an event.
 
     Attributes:
@@ -37,7 +39,7 @@ class EventDetails(mongoengine.EmbeddedDocument):
     )
 
 
-class Event(mongoengine.Document):
+class Event(RestrictedDocument):
     """Main event document storing event data and relationships.
 
     Attributes:

--- a/src/capy_app/backend/db/documents/guild.py
+++ b/src/capy_app/backend/db/documents/guild.py
@@ -2,8 +2,10 @@ import typing
 import datetime
 import mongoengine
 
+from capy_app.backend.db.documents.restrict import RestrictedEmbeddedDocument, RestrictedDocument
 
-class GuildChannels(mongoengine.EmbeddedDocument):
+
+class GuildChannels(RestrictedEmbeddedDocument):
     """Represents Discord channel configuration for a guild.
 
     Attributes:
@@ -17,7 +19,7 @@ class GuildChannels(mongoengine.EmbeddedDocument):
     moderator: typing.Optional[int] = mongoengine.IntField()
 
 
-class GuildRoles(mongoengine.EmbeddedDocument):
+class GuildRoles(RestrictedEmbeddedDocument):
     """Represents role configuration for a guild.
 
     Attributes:
@@ -36,7 +38,7 @@ class GuildRoles(mongoengine.EmbeddedDocument):
     office_hours: typing.Optional[str] = mongoengine.StringField()
 
 
-class OfficeHours(mongoengine.EmbeddedDocument):
+class OfficeHours(RestrictedEmbeddedDocument):
     """Represents office hours schedule for a member.
 
     Attributes:
@@ -48,7 +50,7 @@ class OfficeHours(mongoengine.EmbeddedDocument):
     schedule: typing.Dict[str, typing.List[str]] = mongoengine.DictField()
 
 
-class Guild(mongoengine.Document):
+class Guild(RestrictedDocument):
     """Main guild document representing a Discord server configuration.
 
     Attributes:

--- a/src/capy_app/backend/db/documents/restrict.py
+++ b/src/capy_app/backend/db/documents/restrict.py
@@ -1,13 +1,16 @@
 import datetime
 
 import logging
+from typing import Any, Dict
+
 import mongoengine
+from mongoengine.base import BaseDocument
 
 
-class RestrictedBase(mongoengine.Document):
+class RestrictedBase(BaseDocument):
     """Base class for restricted documents with proper type hints."""
 
-    meta = {"abstract": True}
+    meta: Dict[str, Any] = {"abstract": True}
     logger = logging.getLogger(__name__)
 
     def __setattr__(self, name, value):
@@ -21,7 +24,7 @@ class RestrictedBase(mongoengine.Document):
         super().__setattr__(name, value)
 
     def __delattr__(self, name):
-        err =  AttributeError(
+        err = AttributeError(
             f"Deletion of attribute {name} disallowed on {self.__class__.__name__}"
         )
         self.logger.exception(err, stack_info=True)
@@ -36,8 +39,8 @@ class RestrictedDocument(RestrictedBase, mongoengine.Document):
         default=lambda: datetime.datetime.now(datetime.timezone.utc), auto_now=True
     )
 
-    meta = {"abstract": True}
+    meta: Dict[str, Any] = {"abstract": True}
 
 
 class RestrictedEmbeddedDocument(RestrictedBase, mongoengine.EmbeddedDocument):
-    pass
+    meta: Dict[str, Any] = {"allow_inheritance": True}

--- a/src/capy_app/backend/db/documents/restrict.py
+++ b/src/capy_app/backend/db/documents/restrict.py
@@ -3,7 +3,7 @@ import datetime
 import logging
 from typing import Any, Dict
 
-import mongoengine
+from mongoengine import EmbeddedDocument, Document, DateTimeField
 from mongoengine.base import BaseDocument
 
 
@@ -31,16 +31,16 @@ class RestrictedBase(BaseDocument):
         raise err
 
 
-class RestrictedDocument(RestrictedBase, mongoengine.Document):
-    created_at = mongoengine.DateTimeField(
+class RestrictedDocument(RestrictedBase, Document):
+    created_at = DateTimeField(
         default=lambda: datetime.datetime.now(datetime.timezone.utc)
     )
-    updated_at = mongoengine.DateTimeField(
+    updated_at = DateTimeField(
         default=lambda: datetime.datetime.now(datetime.timezone.utc), auto_now=True
     )
 
     meta: Dict[str, Any] = {"abstract": True}
 
 
-class RestrictedEmbeddedDocument(RestrictedBase, mongoengine.EmbeddedDocument):
+class RestrictedEmbeddedDocument(RestrictedBase, EmbeddedDocument):
     pass

--- a/src/capy_app/backend/db/documents/restrict.py
+++ b/src/capy_app/backend/db/documents/restrict.py
@@ -10,7 +10,7 @@ from mongoengine.base import BaseDocument
 class RestrictedBase(BaseDocument):
     """Base class for restricted documents with proper type hints."""
 
-    meta: Dict[str, Any] = {"abstract": True}
+    meta: Dict[str, Any] = {"abstract": True, "allow_inheritance": True}
     logger = logging.getLogger(__name__)
 
     def __setattr__(self, name, value):
@@ -43,4 +43,4 @@ class RestrictedDocument(RestrictedBase, mongoengine.Document):
 
 
 class RestrictedEmbeddedDocument(RestrictedBase, mongoengine.EmbeddedDocument):
-    meta: Dict[str, Any] = {"allow_inheritance": True}
+    pass

--- a/src/capy_app/backend/db/documents/user.py
+++ b/src/capy_app/backend/db/documents/user.py
@@ -2,8 +2,10 @@ import typing
 import datetime
 import mongoengine
 
+from capy_app.backend.db.documents.restrict import RestrictedDocument, RestrictedEmbeddedDocument
 
-class UserName(mongoengine.EmbeddedDocument):
+
+class UserName(RestrictedEmbeddedDocument):
     """Represents a user's name with first, middle, and last components.
 
     Attributes:
@@ -17,7 +19,7 @@ class UserName(mongoengine.EmbeddedDocument):
     last: str = mongoengine.StringField(required=True)
 
 
-class UserProfile(mongoengine.EmbeddedDocument):
+class UserProfile(RestrictedEmbeddedDocument):
     """Represents detailed user profile information.
 
     Attributes:
@@ -39,7 +41,7 @@ class UserProfile(mongoengine.EmbeddedDocument):
     phone: int = mongoengine.IntField()
 
 
-class User(mongoengine.Document):
+class User(RestrictedDocument):
     """Main user document storing core user data and relationships.
 
     Attributes:
@@ -62,7 +64,7 @@ class User(mongoengine.Document):
         default=datetime.datetime.now
     )
 
-    meta = {"collection": "users", "indexes": ["created_at", "updated_at"]}
+    meta: typing.Dict[str, typing.Any] = {"collection": "users", "indexes": ["created_at", "updated_at"]}
 
     def save(self, *args: typing.Any, **kwargs: typing.Any) -> "User":
         """Override save to update the updated_at timestamp."""

--- a/tests/capy_app/backend/db/documents/restrict_test.py
+++ b/tests/capy_app/backend/db/documents/restrict_test.py
@@ -1,16 +1,18 @@
+from typing import Dict, Any
+
 import pytest
 import mongoengine
 import time
 from datetime import datetime, timezone
 from mongomock import MongoClient
-from src.capy_app.backend.db.documents.restrict import (
+from capy_app.backend.db.documents.restrict import (
     RestrictedDocument,
     RestrictedEmbeddedDocument,
 )
 
 
 class ConcreteRestrictedDocument(RestrictedDocument):
-    meta = {"collection": "test_restricted_document"}
+    meta: Dict[str, Any] = {"collection": "test_restricted_document"}
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
What the title said.

## Summary by Sourcery

Introduce restricted document classes for MongoDB documents and embedded documents. This change modifies the Guild, User, and Event documents, as well as their embedded documents, to inherit from the new restricted classes.

Enhancements:
- Introduce RestrictedDocument and RestrictedEmbeddedDocument classes to provide a base for documents that require restricted access.
- Make Guild, User, and Event documents inherit from RestrictedDocument.
- Make GuildChannels, GuildRoles, OfficeHours, UserName, UserProfile, EventReactions, and EventDetails embedded documents inherit from RestrictedEmbeddedDocument.