### PR TITLE
Add python 3.13 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+.DS_STORE
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -19,3 +19,5 @@ mailjet-rest==1.3.4
 ollama==0.4.7
 pydantic_settings==2.7.1
 pre-commit==4.1.0
+
+audioop-lts; python_version>='3.13'


### PR DESCRIPTION
Just needed to add an audioloop library to requirements_dev

## Summary by Sourcery

New Features:
- Add audioloop library to development dependencies