### PR TITLE
[Bug Fix] Returning modal data before generating response message

### DIFF
--- a/src/capy_app/frontend/cogs/tests/modal_base_test_cog.py
+++ b/src/capy_app/frontend/cogs/tests/modal_base_test_cog.py
@@ -85,9 +85,10 @@ class ModalTestCog(commands.Cog):
         view = DynamicModalView(**MODAL_CONFIGS["direct_modal"])
 
         values, message = await view.initiate_from_interaction(interaction)
+        #! Not sending submitted values
         if values and message:
             try:
-                await message.edit(
+                view._send_status_message(
                     content="Submitted values:\n"
                     + "\n".join(f"{k}: {v}" for k, v in values.items())
                 )

--- a/src/capy_app/frontend/cogs/tests/modal_base_test_cog.py
+++ b/src/capy_app/frontend/cogs/tests/modal_base_test_cog.py
@@ -85,10 +85,9 @@ class ModalTestCog(commands.Cog):
         view = DynamicModalView(**MODAL_CONFIGS["direct_modal"])
 
         values, message = await view.initiate_from_interaction(interaction)
-        #! Not sending submitted values
         if values and message:
             try:
-                view._send_status_message(
+                await message.edit(
                     content="Submitted values:\n"
                     + "\n".join(f"{k}: {v}" for k, v in values.items())
                 )

--- a/src/capy_app/frontend/interactions/bases/modal_base.py
+++ b/src/capy_app/frontend/interactions/bases/modal_base.py
@@ -185,12 +185,6 @@ class DynamicModalView(View):
             await self._modal.wait()
             self._completed = True
 
-        return_values: Tuple[Optional[Dict[str, str]], Optional[Message]] = (
-            (self._modal.values, self._message)
-            if self._modal and self._modal.success
-            else (None, self._message)
-        )
-
         if self._modal and self._modal.success:
             logger.debug("Modal submitted successfully")
             await self._send_status_message("Form submitted successfully")
@@ -204,6 +198,12 @@ class DynamicModalView(View):
             await self._send_status_message(status)
 
         self.stop()
+
+        return_values: Tuple[Optional[Dict[str, str]], Optional[Message]] = (
+            (self._modal.values, self._message)
+            if self._modal and self._modal.success
+            else (None, self._message)
+        )
         return return_values
 
     async def on_timeout(self) -> None:


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Reordered the return statement to ensure status messages are sent before returning modal data, preventing potential race conditions or premature data return