### PR TITLE
[Update] updated license to 2025 and added CAPY name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) [year] [fullname]
+Copyright (c) [2025] [CAPY]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
example

## Summary by Sourcery

Update the project’s LICENSE file to reflect the new year and include the CAPY name

Chores:
- Bump license year to 2025
- Add CAPY name to the license as a copyright holder