### PR TITLE
[Feature] Added new project contributors to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Welcome to **CAPY** — an all-in-one club managerial software built for efficie
 - **Jason Zhang** ([zhangy96@rpi.edu](mailto:zhangy96@rpi.edu))
 - **Shamik Karkhanis** ([karkhs@rpi.edu](mailto:karkhs@rpi.edu))
 
-## **Project Contributors**  
+## **Current Project Contributors**  
 
 - **Kaylee Xie** ([xiek@rpi.edu](mailto:xiek@rpi.edu))
 - **Sayed Imtiazuddin** ([imtias@rpi.edu](mailto:imtias@rpi.edu))
@@ -33,6 +33,8 @@ Welcome to **CAPY** — an all-in-one club managerial software built for efficie
 - **Elias Cueto** ([cuetoe@rpi.edu](mailto:cuetoe@rpi.edu))
 - **Daniel Aube** ([aubed@rpi.edu](mailto:aubed@rpi.edu))
 - **Thomas Doherty** ([dohert7@rpi.edu](mailto:dohert7@rpi.edu))
+
+## **Past Project Contributors**
 - **Vincent Shi** ([shiv@rpi.edu](mailto:shiv@rpi.edu))
 - **Pradeep Giri** ([girip@rpi.edu](mailto:girip@rpi.edu))
 - **Zane Brotherton** ([brothz@rpi.edu](mailto:brothz@rpi.edu))

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Welcome to **CAPY** — an all-in-one club managerial software built for efficie
 - **Thomas Doherty** ([dohert7@rpi.edu](mailto:dohert7@rpi.edu))
 
 ## **Past Project Contributors**
+
 - **Vincent Shi** ([shiv@rpi.edu](mailto:shiv@rpi.edu))
 - **Pradeep Giri** ([girip@rpi.edu](mailto:girip@rpi.edu))
 - **Zane Brotherton** ([brothz@rpi.edu](mailto:brothz@rpi.edu))

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Welcome to **CAPY** — an all-in-one club managerial software built for efficie
 
 ## **Project Contributors**  
 
+- **Kaylee Xie** ([xiek@rpi.edu](mailto:xiek@rpi.edu))
+- **Sayed Imtiazuddin** ([imtias@rpi.edu](mailto:imtias@rpi.edu))
+- **Brian Ng** ([ngb4@rpi.edu](mailto:ngb4@rpi.edu))
+- **Elias Cueto** ([cuetoe@rpi.edu](mailto:cuetoe@rpi.edu))
+- **Daniel Aube** ([aubed@rpi.edu](mailto:aubed@rpi.edu))
+- **Thomas Doherty** ([dohert7@rpi.edu](mailto:dohert7@rpi.edu))
 - **Vincent Shi** ([shiv@rpi.edu](mailto:shiv@rpi.edu))
 - **Pradeep Giri** ([girip@rpi.edu](mailto:girip@rpi.edu))
 - **Zane Brotherton** ([brothz@rpi.edu](mailto:brothz@rpi.edu))


### PR DESCRIPTION
## Summary by Sourcery

Separate project contributors into current and past sections in the README and add six new current contributors

Documentation:
- Rename “Project Contributors” to “Current Project Contributors” in README
- Add six new current contributors to the README
- Introduce a “Past Project Contributors” section for former contributors