### PR TITLE
[Config] updated black and flake8 config to cap lines at 88

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
-  -   repo: local
-      hooks:
+  - repo: local
+    hooks:
       - id: mypy
         name: mypy
         entry: "mypy"
@@ -16,4 +16,4 @@ repos:
       - id: flake8
 default_stages: [pre-commit, pre-push]
 default_language_version:
-    python: python3.12
+  python: python3.12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,6 @@ warn_unreachable = true
 warn_unused_configs = true
 no_implicit_reexport = true
 explicit_package_bases = true
+
+[tool.black]
+line-length = 88

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,4 +24,5 @@ testing =
 capy_app = py.typed
 
 [flake8]
-max-line-length = 160
+max-line-length = 88
+exclude = .venv

--- a/src/capy_app/sys_logger.py
+++ b/src/capy_app/sys_logger.py
@@ -12,14 +12,17 @@ def init_logger():
     if not os.path.exists("logs"):
         os.mkdir("logs")
 
-    logfile = f'logs/{strftime("%Y-%m-%d_%H-%M-%S", gmtime())}@{socket.gethostname()}.log'
-    logging.basicConfig(filename=logfile,
-                        level=logging.INFO)
+    logfile = (
+        f'logs/{strftime("%Y-%m-%d_%H-%M-%S", gmtime())}@{socket.gethostname()}.log'
+    )
+    logging.basicConfig(filename=logfile, level=logging.INFO)
 
     except_logger = logging.getLogger("sys")
 
     def handler(type, value, tb):
-        print(f'{FAIL}ENCOUNTERED {type.__name__}: CHECK {logfile} FOR MORE DETAILS')
-        except_logger.exception("Uncaught exception: {0}".format(str(value)), stack_info=True)
+        print(f"{FAIL}ENCOUNTERED {type.__name__}: CHECK {logfile} FOR MORE DETAILS")
+        except_logger.exception(
+            "Uncaught exception: {0}".format(str(value)), stack_info=True
+        )
 
     sys.excepthook = handler


### PR DESCRIPTION
this creates errors in other files, to be fixed on individual modification for other developers

## Summary by Sourcery

Enforce an 88-character line length across the codebase by updating Black and Flake8 configurations and reformatting affected files.

Enhancements:
- Add a [tool.black] section in pyproject.toml to configure Black's line-length limit.
- Reduce Flake8’s max-line-length to 88 in setup.cfg.
- Rewrap and reformat sys_logger.py to comply with the new 88-character line limit.

CI:
- Clean up indentation and spacing in .pre-commit-config.yaml for local hooks.