### PR TITLE
[Fix] More than two majors or no majors

### DIFF
--- a/src/capy_app/frontend/cogs/features/profile_cog.py
+++ b/src/capy_app/frontend/cogs/features/profile_cog.py
@@ -5,6 +5,7 @@
 """Profile management cog for handling user profiles."""
 
 import logging
+import time
 from typing import Union, Dict
 from pathlib import Path
 
@@ -115,6 +116,10 @@ class ProfileCog(commands.Cog):
         for dropdown_id in values:
             selected.extend(values[dropdown_id])
 
+        if len(selected) > 2:
+            await message.edit(content="You can only select up to 2 majors.", view=10)
+            return ["Not Set"], message  # Limit to max 2 majors total
+
         # TODO Check if more than 2-3 majors and warn
 
         return selected, message  # Limit to max 2 majors total
@@ -182,7 +187,17 @@ class ProfileCog(commands.Cog):
             return
 
         # Get major selection with dropdown using previous message
-        selected_majors, message = await self.get_majors(message, user)
+        while True:
+            try:
+                selected_majors, message = await self.get_majors(message, user)
+                if selected_majors != ["Not Set"]:
+                    break
+
+                await message.edit(content="⚠️ Please select 1 or 2 majors.")
+                time.sleep(1)
+            except Exception as e:
+                await message.edit(content="⚠️ Please select 1 or 2 majors.")
+                time.sleep(1)
 
         # Verify email if needed using previous message
         if not await self.verify_email(message, profile_data["school_email"], user):


### PR DESCRIPTION
I made it so it loops over the form with major selection when it encounters an invalid amount of majors.(more than 2 or 0)

## Summary by Sourcery

Enforce validation on major selection by prompting the user repeatedly with warnings until they choose 1 or 2 majors.

Bug Fixes:
- Reject and warn when more than two majors are selected in profile setup.

Enhancements:
- Loop the major selection prompt in handle_profile until the user selects exactly 1 or 2 majors.
- Display warning messages when the user selects zero or more than two majors.