### PR TITLE
[Fix] Changed flake8 and black max line length

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,4 +27,4 @@ no_implicit_reexport = true
 explicit_package_bases = true
 
 [tool.black]
-line-length = 88
+line-length = 100

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,5 +24,5 @@ testing =
 capy_app = py.typed
 
 [flake8]
-max-line-length = 88
+max-line-length = 100
 exclude = .venv


### PR DESCRIPTION
Changed flake8 and black max line length from 88 to 100 to resolve some formatting errors. Some lines might still have to be manually reformatted.

## Summary by Sourcery

Chores:
- Increase max-line-length for flake8 and black from 88 to 100 in setup.cfg and pyproject.toml