### PR TITLE
[Fix] Profile Create: added a try again button to handle invalid responses to the first modal

### DIFF
--- a/src/capy_app/frontend/cogs/features/profile_cog.py
+++ b/src/capy_app/frontend/cogs/features/profile_cog.py
@@ -36,6 +36,7 @@ class TryAgainView(discord.ui.View):
         self, interaction: discord.Interaction, button: discord.ui.Button
     ):
         await self.parent_cog.handle_profile(interaction, self.action)
+        self.stop()
 
 
 class ProfileCog(commands.Cog):

--- a/src/capy_app/frontend/cogs/features/profile_cog.py
+++ b/src/capy_app/frontend/cogs/features/profile_cog.py
@@ -24,15 +24,19 @@ from .profile_handlers import EmailVerifier
 from .major_handler import MajorHandler
 from .profile_config import PROFILE_CONFIG
 
+
 class TryAgainView(discord.ui.View):
     def __init__(self, parent_cog):
         super().__init__(timeout=60)
         self.parent_cog = parent_cog
 
     @discord.ui.button(label="Try Again", style=discord.ButtonStyle.primary)
-    async def retry_button(self, interaction: discord.Interaction, button: discord.ui.Button):
+    async def retry_button(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ):
         await self.parent_cog.handle_profile(interaction, "create")
-        
+
+
 class ProfileCog(commands.Cog):
     """Profile management cog for handling user profiles."""
 
@@ -88,7 +92,7 @@ class ProfileCog(commands.Cog):
                 await self.delete_profile(interaction)
             elif action == "show":
                 await self.show_profile(interaction)
-   
+
     async def get_profile_data(
         self, interaction: discord.Interaction, action: str, user: User | None
     ) -> tuple[Dict[str, str] | None, discord.Message | None]:
@@ -185,25 +189,30 @@ class ProfileCog(commands.Cog):
         if not profile_data or not message:
             self.logger.info(f"Profile {action} cancelled by {interaction.user}")
             return
-        trycheck=False
-        content=""
-        if not (profile_data["first_name"].isalpha() and profile_data["last_name"].isalpha()):
-            content+="Names cannot consist of numbers or special characters.\n"
-            trycheck=True
+        trycheck = False
+        content = ""
+        if not (
+            profile_data["first_name"].isalpha() and profile_data["last_name"].isalpha()
+        ):
+            content += "Names cannot consist of numbers or special characters.\n"
+            trycheck = True
         if not (profile_data["graduation_year"].isdigit()):
-            content+="Graduation year must be a number.\n"
-            trycheck=True
+            content += "Graduation year must be a number.\n"
+            trycheck = True
         if not (profile_data["student_id"].isdigit()):
-            content+="Student id must be a number.\n"
-            trycheck=True
-        if (profile_data["graduation_year"].isdigit()) and not (int(profile_data["graduation_year"])>2000 and int(profile_data["graduation_year"]) <2100):
-            content+="Graduation year outside of acceptable bounds.\n"
-            trycheck=True
-        if trycheck==True:
+            content += "Student id must be a number.\n"
+            trycheck = True
+        if (profile_data["graduation_year"].isdigit()) and not (
+            int(profile_data["graduation_year"]) > 2000
+            and int(profile_data["graduation_year"]) < 2100
+        ):
+            content += "Graduation year outside of acceptable bounds.\n"
+            trycheck = True
+        if trycheck == True:
             view = TryAgainView(self)
             await message.edit(content=content, view=view)
             return
-            
+
         # Get major selection with dropdown using previous message
         selected_majors, message = await self.get_majors(message, user)
 

--- a/src/capy_app/frontend/cogs/features/profile_cog.py
+++ b/src/capy_app/frontend/cogs/features/profile_cog.py
@@ -12,6 +12,7 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
+import time
 from config import settings
 from backend.db.database import Database as db
 from backend.db.documents.user import User, UserProfile, UserName
@@ -23,7 +24,15 @@ from .profile_handlers import EmailVerifier
 from .major_handler import MajorHandler
 from .profile_config import PROFILE_CONFIG
 
+class TryAgainView(discord.ui.View):
+    def __init__(self, parent_cog):
+        super().__init__(timeout=60)
+        self.parent_cog = parent_cog
 
+    @discord.ui.button(label="Try Again", style=discord.ButtonStyle.primary)
+    async def retry_button(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await self.parent_cog.handle_profile(interaction, "create")
+        
 class ProfileCog(commands.Cog):
     """Profile management cog for handling user profiles."""
 
@@ -79,7 +88,7 @@ class ProfileCog(commands.Cog):
                 await self.delete_profile(interaction)
             elif action == "show":
                 await self.show_profile(interaction)
-
+   
     async def get_profile_data(
         self, interaction: discord.Interaction, action: str, user: User | None
     ) -> tuple[Dict[str, str] | None, discord.Message | None]:
@@ -142,14 +151,6 @@ class ProfileCog(commands.Cog):
         if not values:
             return False
 
-        if not self.email_verifier.verify_code(
-            message.author.id, values["verification_code"]
-        ):
-            await message.edit(content="Invalid verification code!")
-            return False
-        else:
-            return True
-
     async def handle_profile(
         self, interaction: discord.Interaction, action: str
     ) -> None:
@@ -184,14 +185,32 @@ class ProfileCog(commands.Cog):
         if not profile_data or not message:
             self.logger.info(f"Profile {action} cancelled by {interaction.user}")
             return
-
+        trycheck=False
+        content=""
+        if not (profile_data["first_name"].isalpha() and profile_data["last_name"].isalpha()):
+            content+="Names cannot consist of numbers or special characters.\n"
+            trycheck=True
+        if not (profile_data["graduation_year"].isdigit()):
+            content+="Graduation year must be a number.\n"
+            trycheck=True
+        if not (profile_data["student_id"].isdigit()):
+            content+="Student id must be a number.\n"
+            trycheck=True
+        if (profile_data["graduation_year"].isdigit()) and not (int(profile_data["graduation_year"])>2000 and int(profile_data["graduation_year"]) <2100):
+            content+="Graduation year outside of acceptable bounds.\n"
+            trycheck=True
+        if trycheck==True:
+            view = TryAgainView(self)
+            await message.edit(content=content, view=view)
+            return
+            
         # Get major selection with dropdown using previous message
         selected_majors, message = await self.get_majors(message, user)
 
         # Verify email if needed using previous message
         if not await self.verify_email(message, profile_data["school_email"], user):
             return
-        
+
         # Create user profile data
         profile_data = {
             "name": UserName(

--- a/src/capy_app/frontend/cogs/features/profile_cog.py
+++ b/src/capy_app/frontend/cogs/features/profile_cog.py
@@ -142,9 +142,13 @@ class ProfileCog(commands.Cog):
         if not values:
             return False
 
-        return self.email_verifier.verify_code(
+        if not self.email_verifier.verify_code(
             message.author.id, values["verification_code"]
-        )
+        ):
+            await message.edit(content="Invalid verification code!")
+            return False
+        else:
+            return True
 
     async def handle_profile(
         self, interaction: discord.Interaction, action: str
@@ -187,7 +191,7 @@ class ProfileCog(commands.Cog):
         # Verify email if needed using previous message
         if not await self.verify_email(message, profile_data["school_email"], user):
             return
-
+        
         # Create user profile data
         profile_data = {
             "name": UserName(

--- a/src/capy_app/frontend/cogs/features/profile_cog.py
+++ b/src/capy_app/frontend/cogs/features/profile_cog.py
@@ -30,6 +30,7 @@ class TryAgainView(discord.ui.View):
         super().__init__(timeout=60)
         self.parent_cog = parent_cog
         self.action = action
+
     @discord.ui.button(label="Try Again", style=discord.ButtonStyle.primary)
     async def retry_button(
         self, interaction: discord.Interaction, button: discord.ui.Button
@@ -157,6 +158,7 @@ class ProfileCog(commands.Cog):
         return self.email_verifier.verify_code(
             message.author.id, values["verification_code"]
         )
+
     async def handle_profile(
         self, interaction: discord.Interaction, action: str
     ) -> None:
@@ -205,7 +207,7 @@ class ProfileCog(commands.Cog):
             content += "Student ID must be a number.\n"
             trycheck = True
         if (profile_data["graduation_year"].isdigit()) and not (
-            int(profile_data["graduation_year"]) > 2000
+            int(profile_data["graduation_year"]) > 1899
             and int(profile_data["graduation_year"]) < 2100
         ):
             content += "Graduation year outside of acceptable bounds.\n"

--- a/src/capy_app/frontend/cogs/features/profile_cog.py
+++ b/src/capy_app/frontend/cogs/features/profile_cog.py
@@ -26,15 +26,15 @@ from .profile_config import PROFILE_CONFIG
 
 
 class TryAgainView(discord.ui.View):
-    def __init__(self, parent_cog):
+    def __init__(self, parent_cog, action):
         super().__init__(timeout=60)
         self.parent_cog = parent_cog
-
+        self.action = action
     @discord.ui.button(label="Try Again", style=discord.ButtonStyle.primary)
     async def retry_button(
         self, interaction: discord.Interaction, button: discord.ui.Button
     ):
-        await self.parent_cog.handle_profile(interaction, "create")
+        await self.parent_cog.handle_profile(interaction, self.action)
 
 
 class ProfileCog(commands.Cog):
@@ -211,7 +211,7 @@ class ProfileCog(commands.Cog):
             content += "Graduation year outside of acceptable bounds.\n"
             trycheck = True
         if trycheck == True:
-            view = TryAgainView(self)
+            view = TryAgainView(self, action)
             await message.edit(content=content, view=view)
             return
 

--- a/src/capy_app/frontend/cogs/features/profile_cog.py
+++ b/src/capy_app/frontend/cogs/features/profile_cog.py
@@ -154,7 +154,9 @@ class ProfileCog(commands.Cog):
 
         if not values:
             return False
-
+        return self.email_verifier.verify_code(
+            message.author.id, values["verification_code"]
+        )
     async def handle_profile(
         self, interaction: discord.Interaction, action: str
     ) -> None:
@@ -200,7 +202,7 @@ class ProfileCog(commands.Cog):
             content += "Graduation year must be a number.\n"
             trycheck = True
         if not (profile_data["student_id"].isdigit()):
-            content += "Student id must be a number.\n"
+            content += "Student ID must be a number.\n"
             trycheck = True
         if (profile_data["graduation_year"].isdigit()) and not (
             int(profile_data["graduation_year"]) > 2000

--- a/src/capy_app/frontend/cogs/features/profile_config.py
+++ b/src/capy_app/frontend/cogs/features/profile_config.py
@@ -47,7 +47,7 @@ PROFILE_CONFIG = {
     },
     "major_dropdown": {"ephemeral": True, "add_buttons": True, "dropdowns": []},
     "verify_modal": {
-        "ephemeral": True,
+        "ephemeral": True,  
         "button_label": "Enter Verification Code",
         "button_style": ButtonStyle.primary,
         "message_prompt": "📧 A verification code has been sent to your email.\nClick below when ready to verify:",


### PR DESCRIPTION
Handling for invalid submissions couldn't happen automatically because the initial interaction ends upon submitting the modal with how the modal code works right now. Now, the code detects these invalid submissions and offers you the try again button, which re-fires handle_profile. Currently covered is digits in names, letters in id and year, and years outside the 2000-2100 range for graduation, considering the possibility of alumni users and future students.

## Summary by Sourcery

Improve profile creation by validating user inputs and providing a retry option via a Try Again button for invalid submissions

New Features:
- Add a "Try Again" button that reruns the profile creation flow when inputs are invalid

Bug Fixes:
- Handle invalid profile submissions by validating names, student IDs, and graduation years and offering a retry instead of silently failing

Enhancements:
- Introduce input validation for first/last names (alphabetic only), student IDs (digits only), and graduation years (numeric and within 2000–2100)

Chores:
- Remove redundant return logic in email verification and trim trailing whitespace in configuration