### PR TITLE
[Fix] Use secrets for verification codes

### DIFF
--- a/src/capy_app/frontend/cogs/features/profile_cog.py
+++ b/src/capy_app/frontend/cogs/features/profile_cog.py
@@ -136,20 +136,49 @@ class ProfileCog(commands.Cog):
             await message.edit(content="Failed to send verification email.")
             return False
 
-        verify_view = ButtonDynamicModalView(**self.config["verify_modal"])
-        values, _ = await verify_view.initiate_from_message(message)
+        max_attempts = 5
+        attempt = 0
 
-        if not values:
-            return False
+        # Base prompt from config for first attempt
+        base_prompt: str | None = self.config["verify_modal"].get("message_prompt")
 
-        is_valid = self.email_verifier.verify_code(
-            message.author.id, values["verification_code"]
+        while attempt < max_attempts:
+            # Create a fresh view each attempt to avoid state conflicts
+            verify_view = ButtonDynamicModalView(**self.config["verify_modal"])
+
+            # Custom prompt for retries after the first failed attempt
+            if attempt == 0:
+                prompt_msg = base_prompt
+            else:
+                remaining = max_attempts - attempt
+                prompt_msg = (
+                    f"❌ Incorrect verification code. You have {remaining} attempt{'s' if remaining != 1 else ''} left.\n"
+                    "Click below to try again:"
+                )
+
+            values, message = await verify_view.initiate_from_message(
+                message, prompt=prompt_msg
+            )
+
+            # User closed the modal or it timed-out
+            if not values:
+                return False
+
+            is_valid = self.email_verifier.verify_code(
+                message.author.id, values["verification_code"]
+            )
+
+            if is_valid:
+                return True
+
+            attempt += 1
+
+        # Exhausted attempts – inform the user and fail validation
+        await message.edit(
+            content="❌ Too many incorrect verification attempts. Verification failed.",
+            view=None,
         )
-
-        if not is_valid:
-            await message.edit(content="Incorrect verification code.")
-
-        return is_valid
+        return False
 
     async def handle_profile(
         self, interaction: discord.Interaction, action: str

--- a/src/capy_app/frontend/cogs/features/profile_cog.py
+++ b/src/capy_app/frontend/cogs/features/profile_cog.py
@@ -142,9 +142,14 @@ class ProfileCog(commands.Cog):
         if not values:
             return False
 
-        return self.email_verifier.verify_code(
+        is_valid = self.email_verifier.verify_code(
             message.author.id, values["verification_code"]
         )
+
+        if not is_valid:
+            await message.edit(content="Incorrect verification code.")
+
+        return is_valid
 
     async def handle_profile(
         self, interaction: discord.Interaction, action: str

--- a/src/capy_app/frontend/cogs/features/profile_handlers.py
+++ b/src/capy_app/frontend/cogs/features/profile_handlers.py
@@ -9,7 +9,7 @@ and sending verification emails to users.
 #! Email verification is critical for security
 """
 
-import random
+import secrets
 import typing
 
 from backend.modules.email import Email
@@ -33,7 +33,7 @@ class EmailVerifier:
         Returns:
             str: The generated verification code
         """
-        code = "".join(str(random.randint(0, 9)) for _ in range(6))
+        code = "".join(str(secrets.randbelow(10)) for _ in range(6))
         self._codes[user_id] = (code, email)
         return code
 

--- a/src/capy_app/frontend/cogs/features/profile_handlers.py
+++ b/src/capy_app/frontend/cogs/features/profile_handlers.py
@@ -50,7 +50,7 @@ class EmailVerifier:
         if user_id not in self._codes:
             return False
         stored_code, _ = self._codes[user_id]
-        is_valid = code == stored_code
+        is_valid = secrets.compare_digest(code, stored_code)
         if is_valid:
             del self._codes[user_id]
         return is_valid

--- a/tests/capy_app/frontend/test_profile_handlers.py
+++ b/tests/capy_app/frontend/test_profile_handlers.py
@@ -1,0 +1,16 @@
+from capy_app.frontend.cogs.features.profile_handlers import EmailVerifier
+
+
+def test_generate_code_length_and_digits() -> None:
+    verifier = EmailVerifier()
+    code = verifier.generate_code(1, "test@example.com")
+    assert len(code) == 6
+    assert code.isdigit()
+
+
+def test_verify_code_success_and_cleanup() -> None:
+    verifier = EmailVerifier()
+    user_id = 2
+    code = verifier.generate_code(user_id, "other@example.com")
+    assert verifier.verify_code(user_id, code)
+    assert not verifier.verify_code(user_id, code)

--- a/tests/capy_app/frontend/test_profile_handlers.py
+++ b/tests/capy_app/frontend/test_profile_handlers.py
@@ -1,3 +1,24 @@
+import sys
+import types
+
+# Provide dummy backend email module to avoid external dependency
+backend = types.ModuleType("backend")
+modules = types.ModuleType("modules")
+email_module = types.ModuleType("email")
+
+
+class DummyEmail:
+    def send_mail(self, *_, **__):  # pragma: no cover - simple dummy
+        return True
+
+
+email_module.Email = DummyEmail
+modules.email = email_module
+backend.modules = modules
+sys.modules.setdefault("backend", backend)
+sys.modules.setdefault("backend.modules", modules)
+sys.modules.setdefault("backend.modules.email", email_module)
+
 from capy_app.frontend.cogs.features.profile_handlers import EmailVerifier
 
 
@@ -14,3 +35,11 @@ def test_verify_code_success_and_cleanup() -> None:
     code = verifier.generate_code(user_id, "other@example.com")
     assert verifier.verify_code(user_id, code)
     assert not verifier.verify_code(user_id, code)
+
+
+def test_verify_code_failure() -> None:
+    verifier = EmailVerifier()
+    user_id = 3
+    code = verifier.generate_code(user_id, "third@example.com")
+    wrong_code = "000000" if code != "000000" else "111111"
+    assert not verifier.verify_code(user_id, wrong_code)


### PR DESCRIPTION
## Summary
- use `secrets.randbelow` when generating email verification codes
- add unit tests for `EmailVerifier`

## Testing
- `pytest --override-ini addopts="" -q tests/capy_app/frontend/test_profile_handlers.py` *(fails: ModuleNotFoundError: No module named 'mailjet_rest')*

------
https://chatgpt.com/codex/tasks/task_e_686dfff1299483248c4f80030a020efb

## Summary by Sourcery

Use a cryptographically secure random generator for email verification codes and add unit tests for the EmailVerifier.

Enhancements:
- Use secrets.randbelow for generating email verification codes

Tests:
- Add unit tests for EmailVerifier covering code length, digit format, verification success, and cleanup