### PR TITLE
Debug server clear and settings application

### DIFF
--- a/src/capy_backend/db/documents/guild.py
+++ b/src/capy_backend/db/documents/guild.py
@@ -17,7 +17,7 @@ class GuildRoles(RestrictedEmbeddedDocument):
 class Guild(RestrictedDocument):
     users = me.ListField(me.IntField())
     events = me.ListField(me.IntField())
-    channels = me.kEmbeddedDocumentField(GuildChannels, default=GuildChannels)
+    channels = me.EmbeddedDocumentField(GuildChannels, default=GuildChannels)
     roles = me.EmbeddedDocumentField(GuildRoles, default=GuildRoles)
 
     meta = {**RestrictedDocument.meta, "collection": "guilds"}

--- a/src/capy_discord/cogs/event.py
+++ b/src/capy_discord/cogs/event.py
@@ -389,10 +389,27 @@ class Events(commands.Cog):
             await ctx.send("ERROR: Event not found.")
             return
 
-        # Find the #announcements channel
-        announcement_channel = discord.utils.get(
-            ctx.guild.text_channels, name="announcements"
-        )
+        # Get guild settings to find the configured announcements channel
+        guild = self.bot.db.get_data("guild", ctx.guild.id)
+        announcements_channel_id = guild.get_value("announcements_channel")
+        
+        announcement_channel = None
+        
+        # Try to get the channel by ID from guild settings
+        if announcements_channel_id:
+            try:
+                announcement_channel = ctx.guild.get_channel(int(announcements_channel_id))
+            except (ValueError, TypeError):
+                # If the ID is invalid, fall back to looking by name
+                announcement_channel = discord.utils.get(
+                    ctx.guild.text_channels, name=str(announcements_channel_id)
+                )
+        
+        # If no channel found via settings, fall back to looking for "announcements" channel
+        if announcement_channel is None:
+            announcement_channel = discord.utils.get(
+                ctx.guild.text_channels, name="announcements"
+            )
 
         # Create it if it doesn't exist
         if announcement_channel is None:
@@ -407,6 +424,9 @@ class Events(commands.Cog):
                 await announcement_channel.set_permissions(
                     ctx.guild.me, send_messages=True
                 )
+                # Update guild settings with the new channel ID
+                guild.set_value("announcements_channel", announcement_channel.id)
+                self.bot.db.upsert_data(guild)
             except discord.Forbidden:
                 await ctx.send("ERROR: I do not have permission to create channels.")
                 return


### PR DESCRIPTION
Fixes `ValidationError` in guild document schema and ensures event announcements use configured guild settings.

The `ValidationError` for `/server clear` was caused by a typo (`kEmbeddedDocumentField` instead of `EmbeddedDocumentField`) in the `Guild` document definition. Additionally, the event announcement command was hardcoded to use a channel named "announcements" instead of respecting the `announcements_channel` setting in the guild's configuration. This PR corrects both issues, allowing guild data to be saved correctly and ensuring the bot uses the configured announcement channel.

---
<a href="https://cursor.com/background-agent?bcId=bc-9e0b9c98-b2ec-4288-8a33-b3eb43230cd7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9e0b9c98-b2ec-4288-8a33-b3eb43230cd7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

## Summary by Sourcery

Fix schema typo causing ValidationError on server clear and update the announcement command to respect and persist the guild’s configured announcement channel

Bug Fixes:
- Correct typo in Guild document definition by replacing kEmbeddedDocumentField with EmbeddedDocumentField

Enhancements:
- Load announcement channel ID from guild settings with fallback to a default channel
- Persist the newly created announcement channel ID in guild settings upon creation