### PR TITLE
fix: server settings really does set annoucement channel now

### DIFF
--- a/src/capy_app/frontend/cogs/features/event_cog.py
+++ b/src/capy_app/frontend/cogs/features/event_cog.py
@@ -829,15 +829,31 @@ class EventCog(commands.Cog):
             )
             return
 
-        # Find or create announcements channel
-        announcement_channel = discord.utils.get(
-            interaction.guild.text_channels, name="announcements"
-        )  # Use your actual channel name
+        # Resolve announcements channel from server settings (fallback to name if not configured)
+        guild_data = Database.get_document(Guild, interaction.guild.id)
+        announcement_channel: discord.TextChannel | None = None
+        channel_id = (
+            getattr(getattr(guild_data, "channels", None), "announcements", None)
+            if guild_data
+            else None
+        )
+        if channel_id:
+            chan = interaction.guild.get_channel(channel_id)
+            if isinstance(chan, discord.TextChannel):
+                announcement_channel = chan
+        if announcement_channel is None:
+            # Fallback by name for legacy behavior
+            announcement_channel = discord.utils.get(
+                interaction.guild.text_channels, name="announcements"
+            )
 
         if not announcement_channel:
             with suppress(discord.Forbidden, discord.HTTPException):
                 await message.edit(
-                    content="Error: Could not find or create the announcements channel.",
+                    content=(
+                        "Error: Announcements channel is not configured or found. "
+                        "Use /server edit to set the 'Announcements Channel'."
+                    ),
                     view=None,
                     embed=None,
                 )

--- a/src/capy_app/frontend/cogs/features/guild_cog.py
+++ b/src/capy_app/frontend/cogs/features/guild_cog.py
@@ -4,6 +4,7 @@ import logging
 
 import discord
 from backend.db.database import Database
+from backend.db.documents.guild import GuildChannels, GuildRoles
 from discord import app_commands
 from discord.ext import commands
 from frontend import config_colors as colors
@@ -203,12 +204,16 @@ class GuildCog(commands.Cog):
         )
 
         if value:
-            # Clear all settings
+            # Clear all settings by resetting embedded documents to defaults
             updates = {
-                "channels": {},
-                "roles": {},
+                "channels": GuildChannels(),
+                "roles": GuildRoles(),
             }
             Database.update_document(guild_data, updates)
+            if message:
+                await message.edit(content="Server settings cleared.", view=None)
+            else:
+                await interaction.followup.send("Server settings cleared.", ephemeral=True)
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/src/capy_app/frontend/interactions/bases/dropdown_base.py
+++ b/src/capy_app/frontend/interactions/bases/dropdown_base.py
@@ -244,9 +244,17 @@ class DynamicDropdownView(View):
         for dropdown_config in dropdowns:
             selections = dropdown_config.get("selections", [])
             chunks = self.chunk_selections(selections)
-            for chunk in chunks:
+            total = len(chunks)
+            for idx, chunk in enumerate(chunks, start=1):
                 config_copy = dropdown_config.copy()
                 config_copy["selections"] = chunk
+                # If the dropdown exceeds 25 options, clarify pagination within the same category
+                if total > 1 and "placeholder" in config_copy and isinstance(
+                    config_copy["placeholder"], str
+                ):
+                    config_copy["placeholder"] = (
+                        f"{config_copy['placeholder']} (page {idx}/{total})"
+                    )
                 all_chunks.append(config_copy)
         self._dropdowns_data = all_chunks
         self._clear_dropdown()


### PR DESCRIPTION
- now server setting: announcement channel correctly reflects in the event cog
- other channel settings are hardcoded for some reason. not changing for now as they are bug report and feature request channels.

## Summary by Sourcery

Fix announcement channel resolution to use configured server settings and enhance clear settings to properly reset channels and roles with confirmation messaging

Bug Fixes:
- Resolve announcements channel from stored guild settings instead of hardcoded name
- Update error message to instruct users to configure the Announcements Channel via /server edit

Enhancements:
- Reset embedded channel and role documents to defaults when clearing settings
- Edit or follow up with a confirmation message after clearing server settings