### PR TITLE
[Feature] cap-230 Logging command usage statistics

### DIFF
--- a/src/capy_app/config.py
+++ b/src/capy_app/config.py
@@ -1,4 +1,5 @@
 from functools import lru_cache
+from pathlib import Path
 
 from pydantic_settings import BaseSettings
 
@@ -6,6 +7,10 @@ from pydantic_settings import BaseSettings
 class Settings(BaseSettings):
     # Logging settings
     LOG_LEVEL: str | None = "DEBUG"
+    STAT_DUMP_FREQUENCY: float | None = 10  # Minutes
+
+    # This does not need to be in a .env, this was just the cleanest way to store state (plus it only mutates once)
+    STAT_LOG_FILE: Path | None = None
 
     # Bot settings
     BOT_TOKEN: str | None = None

--- a/src/capy_app/config.py
+++ b/src/capy_app/config.py
@@ -9,7 +9,7 @@ class Settings(BaseSettings):
     LOG_LEVEL: str | None = "DEBUG"
     STAT_DUMP_FREQUENCY: float | None = 10  # Minutes
 
-    # This does not need to be in a .env, this was just the cleanest way to store state (plus it only mutates once)
+    # The computed path to the statistics log file. Only mutated at definition.
     STAT_LOG_FILE: Path | None = None
 
     # Bot settings

--- a/src/capy_app/frontend/bot.py
+++ b/src/capy_app/frontend/bot.py
@@ -12,6 +12,7 @@ import discord
 from backend.db.database import Database
 from discord.ext import commands
 from discord.ext.commands import Context
+from stats import Statistics
 
 from config import settings
 
@@ -30,6 +31,7 @@ class Bot(commands.AutoShardedBot):
         self.logger.setLevel(settings.LOG_LEVEL)
 
         self.tree.error(coro=self._dispatch_slash_command_error)
+        self.stats = Statistics()
 
     async def on_member_join(self, member: discord.Member) -> None:
         """Handle event when a new member joins a guild.
@@ -135,6 +137,14 @@ class Bot(commands.AutoShardedBot):
 
     async def _dispatch_slash_command_error(self, interaction, error):
         self.dispatch("slash_command_error", interaction, error)
+
+    async def on_app_command_completion(self, interaction, command) -> None:
+        usages = self.stats.command_usages[command.name]
+        if interaction.user.guild_permissions.administrator:
+            usages.admin_uses += 1
+        # if is_dev(interaction.user.id): TODO implement devcheck
+        #     usages.dev_uses += 1
+        usages.uses += 1
 
     def run_bot(self) -> None:
         """Run the bot instance."""

--- a/src/capy_app/frontend/bot.py
+++ b/src/capy_app/frontend/bot.py
@@ -151,8 +151,8 @@ class Bot(commands.AutoShardedBot):
         usages = self.stats.command_usages[command.name]
         if interaction.user.guild_permissions.administrator:
             usages.admin_uses += 1
-        # if is_dev(interaction.user.id): TODO implement devcheck
-        #     usages.dev_uses += 1
+        if interaction.guild.id == settings.DEBUG_GUILD_ID:
+            usages.dev_uses += 1
         usages.uses += 1
 
     @tasks.loop(minutes=settings.STAT_DUMP_FREQUENCY)

--- a/src/capy_app/frontend/bot.py
+++ b/src/capy_app/frontend/bot.py
@@ -1,19 +1,24 @@
 """Discord bot module for handling discord-related functionality."""
 
+import json
+
 # Standard library imports
 import logging
 import pathlib
 import typing
+from dataclasses import asdict
+from datetime import datetime
+from pathlib import Path
 
 # Third-party imports
 import discord
 
 # Local imports
 from backend.db.database import Database
-from discord.ext import commands
+from discord.ext import commands, tasks
 from discord.ext.commands import Context
-from stats import Statistics
 
+from capy_app.stats import Statistics
 from config import settings
 
 
@@ -32,6 +37,7 @@ class Bot(commands.AutoShardedBot):
 
         self.tree.error(coro=self._dispatch_slash_command_error)
         self.stats = Statistics()
+        self.stat_file = settings.STAT_LOG_FILE
 
     async def on_member_join(self, member: discord.Member) -> None:
         """Handle event when a new member joins a guild.
@@ -98,6 +104,9 @@ class Bot(commands.AutoShardedBot):
         self.logger.info(f"Logged in as {self.user.name} - {self.user.id}")
         self.logger.info(f"Connected to {len(self.guilds)} guilds across {self.shard_count} shards")
 
+        # Start tasks
+        self.output_stats.start()
+
     async def on_message(self, message: discord.Message) -> None:
         """Process incoming messages and commands.
 
@@ -145,6 +154,28 @@ class Bot(commands.AutoShardedBot):
         # if is_dev(interaction.user.id): TODO implement devcheck
         #     usages.dev_uses += 1
         usages.uses += 1
+
+    @tasks.loop(minutes=settings.STAT_DUMP_FREQUENCY)
+    async def output_stats(self):
+        """
+        Dumps the collected statistics for this runtime to a statistics file
+        """
+        try:
+            # Update last write time
+            self.stats.last_dump = datetime.now().isoformat()
+
+            # Marshal data to dict
+            data = asdict(self.stats)
+
+            # Write to file
+            with Path.open(self.stat_file, "w") as file:
+                json.dump(data, file, indent=4)
+                file.close()
+        except Exception as e:
+            self.logger.error(f"Error writing statistics to file: {e}")
+            return
+
+        self.logger.info("Statistics dumped to file")
 
     def run_bot(self) -> None:
         """Run the bot instance."""

--- a/src/capy_app/stats.py
+++ b/src/capy_app/stats.py
@@ -1,3 +1,4 @@
+import datetime
 from collections import defaultdict
 from dataclasses import dataclass, field
 
@@ -21,6 +22,9 @@ class Statistics:
     """
     A class representing the collected statistics of the bot
     """
+
+    # The last time the statistics were written to a file
+    last_dump: str = field(default_factory=datetime.datetime.now().isoformat)
 
     # The usage statistics for all commands
     command_usages: defaultdict[str, CommandUsage] = field(default_factory=lambda: defaultdict(CommandUsage))

--- a/src/capy_app/stats.py
+++ b/src/capy_app/stats.py
@@ -1,0 +1,26 @@
+from collections import defaultdict
+from dataclasses import dataclass, field
+
+
+@dataclass
+class CommandUsage:
+    """
+    A class representing the usage statistics of one command
+    """
+
+    # How many times the command was used
+    uses: int = field(default=0)
+    # How many usages were by server administrators
+    admin_uses: int = field(default=0)
+    # How many usages were by CApy developers
+    dev_uses: int = field(default=0)
+
+
+@dataclass
+class Statistics:
+    """
+    A class representing the collected statistics of the bot
+    """
+
+    # The usage statistics for all commands
+    command_usages: defaultdict[str, CommandUsage] = field(default_factory=lambda: defaultdict(CommandUsage))

--- a/src/capy_app/sys_logger.py
+++ b/src/capy_app/sys_logger.py
@@ -4,16 +4,23 @@ import sys
 from pathlib import Path
 from time import gmtime, strftime
 
+import config
+
 WARNING = "\033[93m"
 FAIL = "\033[91m"
+
+LOGS_DIR = Path(__file__).parents[2].joinpath("logs")
+_STAT_FILE = (
+    Path(__file__).parents[2].joinpath("stats")
+)  # Initially just make it the directory - this changes p much immediately
 
 
 def init_logger():
     # Use pathlib.Path instead of os.path / os.mkdir
-    logs_dir = Path(__file__).parents[2].joinpath("logs")
-    if not logs_dir.exists():
-        logs_dir.mkdir(parents=True)
-    logfile = logs_dir / f"{strftime('%Y-%m-%d_%H-%M-%S', gmtime())}@{socket.gethostname()}.log"
+    if not LOGS_DIR.exists():
+        LOGS_DIR.mkdir(parents=True)
+    formatted_time = strftime("%Y-%m-%d_%H-%M-%S", gmtime())
+    logfile = LOGS_DIR / f"{formatted_time}@{socket.gethostname()}.log"
 
     # Initialize logging to that file
     logging.basicConfig(filename=str(logfile), level=logging.INFO)
@@ -25,3 +32,10 @@ def init_logger():
         except_logger.exception(f"Uncaught exception: {exc_value!s}", stack_info=True)
 
     sys.excepthook = handler
+
+    # Create stats directory if it doesn't exist
+    if not _STAT_FILE.exists():
+        _STAT_FILE.mkdir(parents=True)
+
+    # Assign global stat filepath
+    config.settings.STAT_LOG_FILE = _STAT_FILE.joinpath(f"{formatted_time}@{socket.gethostname()}.stat.log")


### PR DESCRIPTION
Logs a couple of usage statistics to a JSON file every 10 minutes (time is configurable)

## Summary by Sourcery

Enable periodic collection and JSON dumping of bot command usage statistics, tracking total, admin, and developer uses through a new Statistics module and scheduled task

New Features:
- Add periodic JSON logging of command usage statistics at a configurable interval
- Introduce Statistics and CommandUsage dataclasses to record total, admin, and developer command usage

Enhancements:
- Hook into on_app_command_completion to increment usage counts
- Schedule a background task to dump statistics to a file every STAT_DUMP_FREQUENCY minutes
- Extend sys_logger to initialize a stats directory and set STAT_LOG_FILE in configuration
- Add STAT_DUMP_FREQUENCY and STAT_LOG_FILE settings in configuration